### PR TITLE
Fix parsing of decimal input values

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,11 +54,11 @@ function parseTimestring (string, returnUnit, opts) {
   let groups = string
     .toLowerCase()
     .replace(/[^.\w+-]+/g, '')
-    .match(/[-+]?[0-9]+[a-z]+/g)
+    .match(/[-+]?[0-9\.]+[a-z]+/g)
 
   if (groups !== null) {
     groups.forEach(group => {
-      let value = group.match(/[0-9]+/g)[0]
+      let value = group.match(/[0-9\.]+/g)[0]
       let unit = group.match(/[a-z]+/g)[0]
 
       totalSeconds += getSeconds(value, unit, unitValues)


### PR DESCRIPTION
This fixes `1.5 hours` parsing as `5 hours`, or `1.0 hours` as `0 hours`

This was presumably working in 2012 with PR #2 but has since broken.

Now decimal values will parse correctly.