### PR TITLE
Added error checking for when an invalid string is input.

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,6 +63,8 @@ function parseTimestring (string, returnUnit, opts) {
 
       totalSeconds += getSeconds(value, unit, unitValues)
     })
+  } else {
+    throw new Error(`The string [${string}] is invalid for timestring`)
   }
 
   if (returnUnit) {

--- a/test.js
+++ b/test.js
@@ -89,6 +89,14 @@ describe('timestring', () => {
     expect(() => timestring('1g')).to.throw(Error)
   })
 
+  it('throws an error when no numbers are in the timestring', () => {
+    expect(() => timestring('asdf')).to.throw(Error)
+  })
+
+  it('throws an error when numbers tail the timestring', () => {
+    expect(() => timestring('asdf123')).to.throw(Error)
+  })
+
   it('can parse a messy time string', () => {
     expect(timestring('5   D a YS    4 h   2 0     mI  nS')).to.equal(447600)
   })


### PR DESCRIPTION
This PR is to add an error check for when a string is input that contains no valid group matches.

This will notify the caller an error has happened when a string like this is input "asdf" or "ajsdfjasdfj45".

If no matching groups are found, it throws.